### PR TITLE
Fix missing void method calls

### DIFF
--- a/Generator/BindingGenerator.cs
+++ b/Generator/BindingGenerator.cs
@@ -61,7 +61,25 @@ $@"using System;
 
 namespace ImGui
 {{
-    public static class ImGui
+    public extension ImGui
+    {{
+        public extension Vec2
+        {{
+            public readonly static Vec2 Zero = .(0, 0);
+            public readonly static Vec2 Ones = .(1, 1);
+            public readonly static Vec2 OneZero = .(1, 0);
+            public readonly static Vec2 ZeroOne = .(0, 1);
+            public readonly static Vec2 NOneZero = .(-1, 0);
+        }}
+
+        public extension Vec4
+        {{
+            public readonly static Vec4 Zero = .(0, 0, 0, 0);
+            public readonly static Vec4 Ones = .(1, 1, 1, 1);
+        }}
+    }}
+
+	public static class ImGui
     {{
 		public static char8* VERSION = ""{version}"";
 		public static int VERSION_NUM = {version.Replace(".", "")}00;
@@ -165,7 +183,7 @@ namespace ImGui
 
         ";
 
-            foreach (var binding in Bindings.Where(b => !(b is ImGuiImplStruct)))
+			foreach (var binding in Bindings.Where(b => !(b is ImGuiImplStruct)))
 				imguiFile += binding.Serialize().Replace("\n", "\n        ");
 
 			imguiFile = imguiFile.Remove(imguiFile.Length - 4);
@@ -195,8 +213,7 @@ $@"using System;
 
 namespace ImGui
 {{";
-
-			implFile += bindings.Single(b => b is ImGuiImplStruct s && s.Name == implName).Serialize().Replace("\n", "\n    ");
+            implFile += bindings.Single(b => b is ImGuiImplStruct s && s.Name == implName).Serialize().Replace("\n", "\n    ");
 			implFile = implFile.Remove(implFile.Length - 4);
 			implFile += "}";
 			return implFile;

--- a/Generator/ImGui/ImGui.cs
+++ b/Generator/ImGui/ImGui.cs
@@ -6,6 +6,27 @@ namespace ImGuiBeefGenerator.ImGui
     {
         public static readonly string[] ReservedKeywords = { "in", "repeat", "ref", "out", "where" };
 
+        public static readonly Dictionary<string, string> WellKnownDefaultValues = new Dictionary<string, string>()
+        {
+            { "ImVec2(0,0)", "Vec2.Zero" },
+            { "ImVec2(1,1)", "Vec2.Ones" },
+            { "ImVec2(1,0)", "Vec2.OneZero" },
+            { "ImVec2(0,1)", "Vec2.ZeroOne" },
+            { "ImVec2(-1,0)", "Vec2.NOneZero" },
+            { "ImVec4(0,0,0,0)", "Vec4.Zero" },
+            { "ImVec4(1,1,1,1)", "Vec4.Ones" },
+        };
+
+        public static string FixDefaultValue(string value)
+        {
+            if (WellKnownDefaultValues.TryGetValue(value, out string beefValue))
+            {
+                return beefValue;
+            }
+
+            return $".{value.Substring(value.IndexOf("("))}";
+        }
+
         public static string FixType(string type)
         {
             if (type.Contains("_") && !IsFunctionPointer(type) && !type.EndsWith("_t") && !type.EndsWith("_t*"))

--- a/Generator/ImGui/ImGuiInstanceMethodDefinition.cs
+++ b/Generator/ImGui/ImGuiInstanceMethodDefinition.cs
@@ -88,6 +88,10 @@ public {(isStatic ? "static " : "")}{ReturnType} {Name}({newArgs}) {(isStatic ? 
                     serialized += $"    {Name}Impl({Args.ToCallArgs()});\n    return pOut;\n";
                 else if (ReturnType != "void")
                     serialized += $"    return {Name}Impl({Args.ToCallArgs()});\n";
+                else
+                {
+                    serialized += $"\t{Name}Impl({Args.ToCallArgs()});\n";
+                }
 
                 serialized += "}\n";
             }

--- a/Generator/ImGui/ImGuiMethodParameter.cs
+++ b/Generator/ImGui/ImGuiMethodParameter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ImGuiBeefGenerator.ImGui
@@ -34,8 +35,15 @@ namespace ImGuiBeefGenerator.ImGui
                 }
                 else if (defaultValue != "")
                 {
-                    if (defaultValue.EndsWith(")"))
-                        DefaultValue = $".{defaultValue.Substring(defaultValue.IndexOf("("))}";
+                    if (defaultValue.StartsWith("sizeof("))
+                    {
+                        int start = defaultValue.IndexOf("(", StringComparison.Ordinal) + 1;
+                        int end = defaultValue.IndexOf(")", start, StringComparison.Ordinal);
+
+                        DefaultValue = $"sizeof({ImGui.FixType(defaultValue[start .. end])})";
+                    }
+                    else if (defaultValue.EndsWith(")"))
+                        DefaultValue = ImGui.FixDefaultValue(defaultValue);
                     else
                         DefaultValue = ImGui.RemovePrefix(defaultValue);
 


### PR DESCRIPTION
this will solve situation like this:

```
[LinkName("ImFontAtlas_GetTexDataAsRGBA32")]
            private static extern void GetTexDataAsRGBA32Impl(FontAtlas* self, uchar** out_pixels, int32* out_width, int32* out_height, int32* out_bytes_per_pixel);
            public void GetTexDataAsRGBA32(out uchar* out_pixels, out int32 out_width, out int32 out_height, int32* out_bytes_per_pixel = null) mut
            {
                out_pixels = ?;
                out_width = ?;
                out_height = ?;
            }
```

to

```
[LinkName("ImFontAtlas_GetTexDataAsRGBA32")]
            private static extern void GetTexDataAsRGBA32Impl(FontAtlas* self, uchar** out_pixels, int32* out_width, int32* out_height, int32* out_bytes_per_pixel);
            public void GetTexDataAsRGBA32(out uchar* out_pixels, out int32 out_width, out int32 out_height, int32* out_bytes_per_pixel = null) mut
            {
                out_pixels = ?;
                out_width = ?;
                out_height = ?;
            	GetTexDataAsRGBA32Impl(&this, &out_pixels, &out_width, &out_height, out_bytes_per_pixel);
            }
```